### PR TITLE
fix: Phase 1.5 baseline test fixes

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "pytest-cov>=6.0.0",
     "aiosqlite>=0.20.0",
     "pillow>=11.0.0",         # For generating test images
+    "greenlet>=3.3.0",        # Required for SQLAlchemy async
 
     # Code Quality
     "ruff>=0.8.0",

--- a/backend/tests/api/test_images.py
+++ b/backend/tests/api/test_images.py
@@ -42,7 +42,8 @@ class TestUploadImage:
 
         assert response.status_code == 400
         data = response.json()
-        assert data["error"]["code"] == "INVALID_FILE_FORMAT"
+        # FastAPI HTTPException uses "detail" key
+        assert data["detail"]["code"] == "INVALID_FILE_FORMAT"
 
     async def test_upload_no_file(self, client: AsyncClient):
         """Uploading without a file returns 422."""
@@ -77,7 +78,8 @@ class TestGetImageMetadata:
 
         assert response.status_code == 404
         data = response.json()
-        assert data["error"]["code"] == "IMAGE_NOT_FOUND"
+        # FastAPI HTTPException uses "detail" key
+        assert data["detail"]["code"] == "IMAGE_NOT_FOUND"
 
 
 class TestDownloadImage:


### PR DESCRIPTION
## Summary
- Add `greenlet>=3.3.0` to dev dependencies (required for SQLAlchemy async with aiosqlite)
- Fix test assertions to use `data["detail"]["code"]` instead of `data["error"]["code"]` (matches FastAPI HTTPException response format)

## Changes
- **backend/pyproject.toml**: Added greenlet dependency
- **backend/tests/api/test_images.py**: Fixed 2 test assertions

## Test plan
- [x] All 11 API tests pass locally (`uv run pytest tests/api -v`)
- [x] No breaking changes to API behavior
- [x] Baseline established for Phase 1.5 development

🤖 Generated with [Claude Code](https://claude.com/claude-code)