### PR TITLE
fix(cd): include scripts/ folder in deployment package

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -188,7 +188,8 @@ jobs:
             backend/ \
             deploy/docker-compose.yml \
             deploy/docker-compose.local.yml \
-            deploy/Caddyfile
+            deploy/Caddyfile \
+            scripts/
 
       - name: Copy files to server
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
The backup and restore scripts were not being deployed because scripts/ was missing from the tar archive.