### PR TITLE
feat: require authentication for image uploads

### DIFF
--- a/backend/app/api/web.py
+++ b/backend/app/api/web.py
@@ -123,7 +123,9 @@ async def upload_page(
     request: Request,
     user: User | None = Depends(get_current_user_from_cookie),
 ):
-    """Upload page - Form to upload a new image."""
+    """Upload page - Form to upload a new image. Requires authentication."""
+    if not user:
+        return RedirectResponse(url="/login?next=/upload", status_code=302)
     templates = get_templates(request)
     return templates.TemplateResponse(
         request=request,

--- a/backend/tests/api/test_images.py
+++ b/backend/tests/api/test_images.py
@@ -6,11 +6,14 @@ from httpx import AsyncClient
 class TestUploadImage:
     """Tests for POST /api/v1/images/upload."""
 
-    async def test_upload_valid_jpeg(self, client: AsyncClient, sample_jpeg_bytes: bytes):
+    async def test_upload_valid_jpeg(
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
+    ):
         """Uploading a valid JPEG returns 201 with metadata including dimensions."""
         response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
 
         assert response.status_code == 201
@@ -24,11 +27,14 @@ class TestUploadImage:
         assert data["width"] == 100  # Test fixture creates 100x100 image
         assert data["height"] == 100
 
-    async def test_upload_valid_png(self, client: AsyncClient, sample_png_bytes: bytes):
+    async def test_upload_valid_png(
+        self, client: AsyncClient, sample_png_bytes: bytes, auth_headers: dict
+    ):
         """Uploading a valid PNG returns 201 with metadata including dimensions."""
         response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.png", sample_png_bytes, "image/png")},
+            headers=auth_headers,
         )
 
         assert response.status_code == 201
@@ -38,11 +44,14 @@ class TestUploadImage:
         assert data["width"] == 100  # Test fixture creates 100x100 image
         assert data["height"] == 100
 
-    async def test_upload_invalid_file_type(self, client: AsyncClient, invalid_file_bytes: bytes):
+    async def test_upload_invalid_file_type(
+        self, client: AsyncClient, invalid_file_bytes: bytes, auth_headers: dict
+    ):
         """Uploading a non-image returns 400 with error."""
         response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.txt", invalid_file_bytes, "text/plain")},
+            headers=auth_headers,
         )
 
         assert response.status_code == 400
@@ -50,26 +59,42 @@ class TestUploadImage:
         # FastAPI HTTPException uses "detail" key
         assert data["detail"]["code"] == "INVALID_FILE_FORMAT"
 
-    async def test_upload_no_file(self, client: AsyncClient):
+    async def test_upload_no_file(self, client: AsyncClient, auth_headers: dict):
         """Uploading without a file returns 422."""
-        response = await client.post("/api/v1/images/upload")
+        response = await client.post("/api/v1/images/upload", headers=auth_headers)
 
         assert response.status_code == 422
+
+    async def test_upload_requires_authentication(
+        self, client: AsyncClient, sample_jpeg_bytes: bytes
+    ):
+        """Uploading without authentication returns 401."""
+        response = await client.post(
+            "/api/v1/images/upload",
+            files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+        )
+
+        assert response.status_code == 401
+        data = response.json()
+        assert data["detail"]["code"] == "UNAUTHORIZED"
 
 
 class TestGetImageMetadata:
     """Tests for GET /api/v1/images/{image_id}."""
 
-    async def test_get_existing_image(self, client: AsyncClient, sample_jpeg_bytes: bytes):
+    async def test_get_existing_image(
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
+    ):
         """Getting metadata for existing image returns 200 with dimensions."""
         # Upload first
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
-        # Get metadata
+        # Get metadata (no auth required for viewing)
         response = await client.get(f"/api/v1/images/{image_id}")
 
         assert response.status_code == 200
@@ -93,16 +118,19 @@ class TestGetImageMetadata:
 class TestDownloadImage:
     """Tests for GET /api/v1/images/{image_id}/file."""
 
-    async def test_download_existing_image(self, client: AsyncClient, sample_jpeg_bytes: bytes):
+    async def test_download_existing_image(
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
+    ):
         """Downloading existing image returns file content."""
         # Upload first
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
-        # Download
+        # Download (no auth required for viewing)
         response = await client.get(f"/api/v1/images/{image_id}/file")
 
         assert response.status_code == 200
@@ -110,13 +138,14 @@ class TestDownloadImage:
         assert len(response.content) == len(sample_jpeg_bytes)
 
     async def test_download_includes_filename_in_header(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Content-Disposition header should include original filename with extension."""
         # Upload with a specific filename
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("my_photo.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -139,19 +168,22 @@ class TestDownloadImage:
 class TestDeleteImage:
     """Tests for DELETE /api/v1/images/{image_id}."""
 
-    async def test_delete_existing_image(self, client: AsyncClient, sample_jpeg_bytes: bytes):
-        """Deleting existing image with delete token returns 204."""
-        # Upload first (anonymous gets delete_token)
+    async def test_delete_own_image(
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
+    ):
+        """Authenticated user can delete their own image."""
+        # Upload first
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
-        delete_token = upload_response.json()["delete_token"]
 
-        # Delete with token
+        # Delete with auth (owner can delete)
         response = await client.delete(
-            f"/api/v1/images/{image_id}", params={"delete_token": delete_token}
+            f"/api/v1/images/{image_id}",
+            headers=auth_headers,
         )
 
         assert response.status_code == 204
@@ -160,10 +192,11 @@ class TestDeleteImage:
         get_response = await client.get(f"/api/v1/images/{image_id}")
         assert get_response.status_code == 404
 
-    async def test_delete_nonexistent_image(self, client: AsyncClient):
+    async def test_delete_nonexistent_image(self, client: AsyncClient, auth_headers: dict):
         """Deleting nonexistent image returns 404."""
         response = await client.delete(
-            "/api/v1/images/nonexistent-id", params={"delete_token": "any_token"}
+            "/api/v1/images/nonexistent-id",
+            headers=auth_headers,
         )
 
         assert response.status_code == 404

--- a/backend/tests/api/test_thumbnails.py
+++ b/backend/tests/api/test_thumbnails.py
@@ -9,12 +9,13 @@ class TestUploadWithThumbnail:
 
     @pytest.mark.asyncio
     async def test_upload_response_includes_thumbnail_ready_false(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Upload response should include thumbnail_ready=False."""
         response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
 
         assert response.status_code == 201
@@ -24,12 +25,13 @@ class TestUploadWithThumbnail:
 
     @pytest.mark.asyncio
     async def test_upload_response_includes_thumbnail_url_none(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Upload response should include thumbnail_url=None initially."""
         response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
 
         assert response.status_code == 201
@@ -43,13 +45,14 @@ class TestGetMetadataWithThumbnail:
 
     @pytest.mark.asyncio
     async def test_metadata_includes_thumbnail_ready(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Metadata response should include thumbnail_ready field."""
         # Upload an image first
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -64,13 +67,14 @@ class TestGetMetadataWithThumbnail:
 
     @pytest.mark.asyncio
     async def test_metadata_includes_thumbnail_url(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Metadata response should include thumbnail_url field."""
         # Upload an image first
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -96,13 +100,14 @@ class TestThumbnailEndpoint:
 
     @pytest.mark.asyncio
     async def test_thumbnail_endpoint_for_new_image(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """After upload, thumbnail should be accessible (background task runs in test)."""
         # Upload an image
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -146,7 +151,9 @@ class TestThumbnailEndpointWithReadyThumbnail:
     """Test thumbnail endpoint when thumbnail is available."""
 
     @pytest.mark.asyncio
-    async def test_thumbnail_returns_jpeg(self, client: AsyncClient, sample_jpeg_bytes: bytes):
+    async def test_thumbnail_returns_jpeg(
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
+    ):
         """When thumbnail is ready, should return JPEG image."""
         # This test requires manually triggering thumbnail generation
         # since background tasks don't run synchronously in tests
@@ -155,6 +162,7 @@ class TestThumbnailEndpointWithReadyThumbnail:
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -173,13 +181,14 @@ class TestThumbnailEndpointWithReadyThumbnail:
 
     @pytest.mark.asyncio
     async def test_thumbnail_is_smaller_than_original(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Thumbnail should be smaller than original image."""
         # Upload an image
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -198,13 +207,14 @@ class TestThumbnailEndpointWithReadyThumbnail:
 
     @pytest.mark.asyncio
     async def test_thumbnail_has_content_disposition(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Thumbnail response should have Content-Disposition header."""
         # Upload an image
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -227,13 +237,14 @@ class TestMetadataAfterThumbnailGenerated:
 
     @pytest.mark.asyncio
     async def test_metadata_shows_thumbnail_ready_true(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Metadata should show thumbnail_ready=True after generation."""
         # Upload an image
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 
@@ -252,13 +263,14 @@ class TestMetadataAfterThumbnailGenerated:
 
     @pytest.mark.asyncio
     async def test_metadata_shows_thumbnail_url(
-        self, client: AsyncClient, sample_jpeg_bytes: bytes
+        self, client: AsyncClient, sample_jpeg_bytes: bytes, auth_headers: dict
     ):
         """Metadata should include thumbnail_url after generation."""
         # Upload an image
         upload_response = await client.post(
             "/api/v1/images/upload",
             files={"file": ("test.jpg", sample_jpeg_bytes, "image/jpeg")},
+            headers=auth_headers,
         )
         image_id = upload_response.json()["id"]
 


### PR DESCRIPTION
## Summary

- Require authentication for image uploads - anonymous users can no longer upload images
- `/upload` web page redirects unauthenticated users to `/login?next=/upload`
- Updated all tests to use authentication fixtures

## Breaking Change

Anonymous uploads are no longer allowed. The upload API endpoint now returns 401 Unauthorized for unauthenticated requests.

## Security

This addresses the security concern where anonymous users could upload unlimited images to the production site (https://chitram.io).

## Changes

| File | Change |
|------|--------|
| `backend/app/api/images.py` | Changed upload endpoint to require authentication |
| `backend/app/api/web.py` | Added redirect for unauthenticated upload page access |
| `backend/tests/conftest.py` | Added `test_user`, `auth_token`, `auth_headers` fixtures |
| `backend/tests/api/test_images.py` | Updated all upload tests with auth |
| `backend/tests/api/test_images_auth.py` | Rewrote auth tests (removed obsolete anonymous tests) |
| `backend/tests/api/test_thumbnails.py` | Updated thumbnail tests with auth |
| `backend/tests/integration/test_web_routes.py` | Moved upload tests to auth-protected section |

## Test plan

- [x] All 221 tests pass locally
- [x] Pre-commit hooks pass (ruff lint/format)
- [x] CI pipeline passes
- [ ] Verify on production that anonymous uploads are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)