### PR TITLE
fix: add Authorization headers to authenticated API calls

### DIFF
--- a/backend/app/templates/image.html
+++ b/backend/app/templates/image.html
@@ -166,17 +166,13 @@
                 >
                     Cancel
                 </button>
-                <form action="/api/v1/images/{{ image.id }}" method="POST" class="flex-1">
-                    <input type="hidden" name="_method" value="DELETE">
-                    <button
-                        type="submit"
-                        hx-delete="/api/v1/images/{{ image.id }}"
-                        hx-confirm="false"
-                        class="w-full bg-red-500 hover:bg-red-600 py-2 px-4 rounded-lg font-medium transition-colors"
-                    >
-                        Delete
-                    </button>
-                </form>
+                <button
+                    id="delete-confirm-btn"
+                    onclick="deleteImage()"
+                    class="flex-1 bg-red-500 hover:bg-red-600 py-2 px-4 rounded-lg font-medium transition-colors"
+                >
+                    Delete
+                </button>
             </div>
         </div>
     </div>
@@ -199,6 +195,46 @@
 
         function closeModal() {
             document.getElementById('delete-modal').classList.add('hidden');
+        }
+
+        async function deleteImage() {
+            const btn = document.getElementById('delete-confirm-btn');
+            btn.disabled = true;
+            btn.textContent = 'Deleting...';
+
+            try {
+                // Get auth token from cookie
+                const authToken = document.cookie
+                    .split('; ')
+                    .find(row => row.startsWith('chitram_auth='))
+                    ?.split('=')[1];
+
+                const headers = {};
+                if (authToken) {
+                    headers['Authorization'] = `Bearer ${authToken}`;
+                }
+
+                const response = await fetch('/api/v1/images/{{ image.id }}', {
+                    method: 'DELETE',
+                    headers: headers,
+                });
+
+                if (response.ok || response.status === 204) {
+                    // Redirect to home after successful deletion
+                    window.location.href = '/';
+                } else {
+                    const data = await response.json();
+                    alert(data.detail?.message || 'Failed to delete image');
+                    closeModal();
+                    btn.disabled = false;
+                    btn.textContent = 'Delete';
+                }
+            } catch (error) {
+                alert('Network error. Please try again.');
+                closeModal();
+                btn.disabled = false;
+                btn.textContent = 'Delete';
+            }
         }
 
         // Close modal on escape

--- a/backend/app/templates/my_images.html
+++ b/backend/app/templates/my_images.html
@@ -133,8 +133,20 @@
         btn.textContent = 'Deleting...';
 
         try {
+            // Get auth token from cookie
+            const authToken = document.cookie
+                .split('; ')
+                .find(row => row.startsWith('chitram_auth='))
+                ?.split('=')[1];
+
+            const headers = {};
+            if (authToken) {
+                headers['Authorization'] = `Bearer ${authToken}`;
+            }
+
             const response = await fetch(`/api/v1/images/${imageToDelete}`, {
                 method: 'DELETE',
+                headers: headers,
             });
 
             if (response.ok || response.status === 204) {

--- a/backend/app/templates/upload.html
+++ b/backend/app/templates/upload.html
@@ -209,8 +209,20 @@
         document.getElementById('submit-spinner').classList.remove('hidden');
 
         try {
+            // Get auth token from cookie
+            const authToken = document.cookie
+                .split('; ')
+                .find(row => row.startsWith('chitram_auth='))
+                ?.split('=')[1];
+
+            const headers = {};
+            if (authToken) {
+                headers['Authorization'] = `Bearer ${authToken}`;
+            }
+
             const response = await fetch('/api/v1/images/upload', {
                 method: 'POST',
+                headers: headers,
                 body: formData,
             });
 


### PR DESCRIPTION
## Summary
- Add Authorization header to image upload POST request in `upload.html`
- Add Authorization header to image delete request in `my_images.html`
- Replace HTMX delete with JavaScript fetch + auth header in `image.html`

### Root Cause
Templates store JWT in `chitram_auth` cookie but the API requires `Authorization: Bearer <token>` header. This caused 401 UNAUTHORIZED errors when users tried to upload or delete images.

### Fix
All three templates now:
1. Read the `chitram_auth` cookie
2. Include `Authorization: Bearer <token>` header in fetch() calls

## Test Results
- 225 tests passing
- No test coverage changes (frontend JS not unit tested)

## Related
- Follows up on PR #22 which fixed auth API paths
- Fixes production 401 errors for upload and delete operations

---
Generated with [Claude Code](https://claude.com/claude-code)