### PR TITLE
feat(auth): Pluggable Authentication System (Phase 3.5)

### DIFF
--- a/backend/alembic/versions/c3e5f8a92b1d_add_supabase_id_to_users.py
+++ b/backend/alembic/versions/c3e5f8a92b1d_add_supabase_id_to_users.py
@@ -1,0 +1,60 @@
+"""add_supabase_id_to_users
+
+Phase 3.5: Add supabase_id column and make password_hash nullable.
+Enables Supabase auth integration while preserving local auth.
+
+Revision ID: c3e5f8a92b1d
+Revises: 42cb2a9fa7a2
+Create Date: 2026-01-07 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3e5f8a92b1d"
+down_revision: str | None = "42cb2a9fa7a2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add supabase_id column and make password_hash nullable."""
+    # Add supabase_id column for external provider linking
+    op.add_column(
+        "users",
+        sa.Column("supabase_id", sa.String(36), nullable=True),
+    )
+    # Add unique index for efficient lookup
+    op.create_index(
+        "ix_users_supabase_id",
+        "users",
+        ["supabase_id"],
+        unique=True,
+    )
+
+    # Make password_hash nullable (Supabase users don't need local hash)
+    op.alter_column(
+        "users",
+        "password_hash",
+        existing_type=sa.String(255),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Remove supabase_id column and make password_hash non-nullable."""
+    # Revert password_hash to non-nullable
+    # Note: This will fail if there are users with NULL password_hash
+    op.alter_column(
+        "users",
+        "password_hash",
+        existing_type=sa.String(255),
+        nullable=False,
+    )
+
+    # Remove supabase_id index and column
+    op.drop_index("ix_users_supabase_id", table_name="users")
+    op.drop_column("users", "supabase_id")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -66,6 +66,13 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 1440  # 24 hours
 
+    # Auth Provider (Phase 3.5)
+    auth_provider: str = "local"  # "local" or "supabase"
+
+    # Supabase Configuration (only used when auth_provider = "supabase")
+    supabase_url: str | None = None
+    supabase_anon_key: str | None = None
+
     @property
     def max_file_size_bytes(self) -> int:
         """Max file size in bytes."""

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -15,7 +15,11 @@ def utc_now() -> datetime:
 
 
 class User(Base):
-    """User model for authentication."""
+    """User model for authentication.
+
+    Supports both local auth (password_hash) and external providers (supabase_id).
+    For Supabase users, password_hash may be None as auth is handled externally.
+    """
 
     __tablename__ = "users"
 
@@ -25,12 +29,17 @@ class User(Base):
         default=generate_uuid,
     )
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
-    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=utc_now,
         nullable=False,
+    )
+
+    # External provider ID (e.g., Supabase user UUID)
+    supabase_id: Mapped[str | None] = mapped_column(
+        String(36), unique=True, nullable=True, index=True
     )
 
     def __repr__(self) -> str:

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -43,3 +43,15 @@ class AuthResponse(BaseModel):
     user: UserResponse
     access_token: str
     token_type: str = "bearer"
+
+
+class PasswordResetRequest(BaseModel):
+    """Password reset request."""
+
+    email: EmailStr
+
+
+class PasswordResetResponse(BaseModel):
+    """Password reset response."""
+
+    message: str = "If the email exists, a password reset link has been sent"

--- a/backend/app/services/auth/__init__.py
+++ b/backend/app/services/auth/__init__.py
@@ -1,0 +1,15 @@
+"""Auth provider module for pluggable authentication."""
+
+from app.services.auth.base import AuthError, AuthErrorCode, AuthProvider, TokenPair, UserInfo
+from app.services.auth.factory import create_auth_provider
+from app.services.auth.local import LocalAuthProvider
+
+__all__ = [
+    "AuthError",
+    "AuthErrorCode",
+    "AuthProvider",
+    "LocalAuthProvider",
+    "TokenPair",
+    "UserInfo",
+    "create_auth_provider",
+]

--- a/backend/app/services/auth/base.py
+++ b/backend/app/services/auth/base.py
@@ -1,0 +1,147 @@
+"""Base authentication provider interface and types.
+
+This module defines the AuthProvider abstract base class that all
+authentication providers must implement. Follows the Strategy pattern
+used by StorageBackend in this codebase.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+
+
+class AuthErrorCode(str, Enum):
+    """Machine-readable error codes for auth operations."""
+
+    INVALID_CREDENTIALS = "INVALID_CREDENTIALS"
+    EMAIL_EXISTS = "EMAIL_EXISTS"
+    USER_NOT_FOUND = "USER_NOT_FOUND"
+    USER_INACTIVE = "USER_INACTIVE"
+    INVALID_TOKEN = "INVALID_TOKEN"
+    TOKEN_EXPIRED = "TOKEN_EXPIRED"
+    PROVIDER_ERROR = "PROVIDER_ERROR"
+    WEAK_PASSWORD = "WEAK_PASSWORD"
+    INVALID_EMAIL = "INVALID_EMAIL"
+
+
+@dataclass(frozen=True)
+class AuthError:
+    """Domain error for authentication failures.
+
+    Immutable dataclass to ensure error details can't be accidentally modified.
+    """
+
+    code: AuthErrorCode
+    message: str
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for HTTP responses."""
+        return {"code": self.code.value, "message": self.message}
+
+
+@dataclass(frozen=True)
+class UserInfo:
+    """User information returned by auth providers.
+
+    Provider-agnostic user representation. The local_user_id is the
+    ID in our local database (used for FKs to images table).
+    """
+
+    local_user_id: str  # Our DB user.id - used for image FKs
+    email: str
+    is_active: bool
+    provider: str  # "local" or "supabase"
+    external_id: str | None = None  # Supabase user ID, if applicable
+
+
+@dataclass(frozen=True)
+class TokenPair:
+    """Access and refresh tokens."""
+
+    access_token: str
+    refresh_token: str | None = None
+    expires_in: int | None = None  # Seconds until access_token expires
+
+
+class AuthProvider(ABC):
+    """Abstract base class for authentication providers.
+
+    All auth providers must implement these methods. The interface is
+    designed to be minimal - only 5 core operations needed.
+    """
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Return provider identifier (e.g., 'local', 'supabase')."""
+        ...
+
+    @abstractmethod
+    async def register(
+        self,
+        email: str,
+        password: str,
+    ) -> UserInfo | AuthError:
+        """Register a new user.
+
+        Returns UserInfo on success, AuthError on failure.
+        Provider is responsible for:
+        - Validating email format
+        - Checking password strength
+        - Creating user in their system
+        - Syncing to local DB if external provider
+        """
+        ...
+
+    @abstractmethod
+    async def login(
+        self,
+        email: str,
+        password: str,
+    ) -> tuple[UserInfo, TokenPair] | AuthError:
+        """Authenticate user and return tokens.
+
+        Returns (UserInfo, TokenPair) on success, AuthError on failure.
+        Provider handles:
+        - Credential verification
+        - Token generation
+        - Local DB sync for external providers
+        """
+        ...
+
+    @abstractmethod
+    async def verify_token(
+        self,
+        token: str,
+    ) -> UserInfo | AuthError:
+        """Verify access token and return user info.
+
+        Returns UserInfo if token is valid, AuthError otherwise.
+        Used by get_current_user dependency.
+        """
+        ...
+
+    @abstractmethod
+    async def refresh_token(
+        self,
+        refresh_token: str,
+    ) -> TokenPair | AuthError:
+        """Refresh access token using refresh token.
+
+        Returns new TokenPair on success, AuthError on failure.
+        LocalAuthProvider may return AuthError with NOT_SUPPORTED
+        if refresh tokens aren't implemented.
+        """
+        ...
+
+    @abstractmethod
+    async def request_password_reset(
+        self,
+        email: str,
+    ) -> bool:
+        """Request password reset email.
+
+        Returns True if request was processed (doesn't reveal if email exists).
+        For security, always returns True even if email not found.
+        """
+        ...

--- a/backend/app/services/auth/factory.py
+++ b/backend/app/services/auth/factory.py
@@ -1,0 +1,39 @@
+"""Factory for creating auth providers based on configuration.
+
+This module provides the create_auth_provider function that instantiates
+the appropriate auth provider based on settings.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import Settings
+from app.services.auth.base import AuthProvider
+from app.services.auth.local import LocalAuthProvider
+
+
+def create_auth_provider(
+    db: AsyncSession,
+    settings: Settings,
+) -> AuthProvider:
+    """Create auth provider based on settings.
+
+    Args:
+        db: Database session for user operations
+        settings: Application settings
+
+    Returns:
+        AuthProvider instance based on settings.auth_provider
+
+    Raises:
+        ValueError: If auth_provider setting is invalid
+    """
+    provider_type = getattr(settings, "auth_provider", "local")
+
+    if provider_type == "local":
+        return LocalAuthProvider(db=db, settings=settings)
+    if provider_type == "supabase":
+        # Import here to avoid circular imports and allow optional dependency
+        from app.services.auth.supabase import SupabaseAuthProvider
+
+        return SupabaseAuthProvider(db=db, settings=settings)
+    raise ValueError(f"Unknown auth provider: {provider_type}")

--- a/backend/app/services/auth/local.py
+++ b/backend/app/services/auth/local.py
@@ -1,0 +1,235 @@
+"""Local authentication provider using bcrypt + JWT.
+
+This provider implements the existing authentication logic from
+auth_service.py, wrapped in the AuthProvider interface.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import bcrypt as bcrypt_lib
+from jose import JWTError, jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import Settings
+from app.models.user import User
+from app.services.auth.base import (
+    AuthError,
+    AuthErrorCode,
+    AuthProvider,
+    TokenPair,
+    UserInfo,
+)
+
+# bcrypt work factor 12 (takes ~200-400ms to hash)
+BCRYPT_WORK_FACTOR = 12
+
+
+class LocalAuthProvider(AuthProvider):
+    """Local authentication using bcrypt password hashing and JWT tokens.
+
+    This is the default provider that stores users in our PostgreSQL database.
+    Passwords are hashed with bcrypt (work factor 12) and tokens are JWTs.
+    """
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        settings: Settings,
+    ):
+        self._db = db
+        self._settings = settings
+
+    @property
+    def provider_name(self) -> str:
+        return "local"
+
+    # --- Password Hashing (internal) ---
+
+    def _hash_password(self, password: str) -> str:
+        """Hash password using bcrypt with work factor 12."""
+        salt = bcrypt_lib.gensalt(rounds=BCRYPT_WORK_FACTOR)
+        hashed = bcrypt_lib.hashpw(password.encode("utf-8"), salt)
+        return hashed.decode("utf-8")
+
+    def _verify_password(self, plain_password: str, hashed_password: str) -> bool:
+        """Verify password against hash using timing-safe comparison."""
+        try:
+            return bcrypt_lib.checkpw(
+                plain_password.encode("utf-8"), hashed_password.encode("utf-8")
+            )
+        except Exception:
+            return False
+
+    # --- JWT Token Management (internal) ---
+
+    def _create_access_token(self, user_id: str) -> str:
+        """Create JWT access token with user_id as subject."""
+        expire = datetime.now(UTC) + timedelta(minutes=self._settings.jwt_expire_minutes)
+        payload = {
+            "sub": user_id,
+            "exp": expire,
+            "iat": datetime.now(UTC),
+            "provider": "local",
+        }
+        return jwt.encode(
+            payload,
+            self._settings.jwt_secret_key,
+            algorithm=self._settings.jwt_algorithm,
+        )
+
+    def _decode_token(self, token: str) -> dict | None:
+        """Decode and verify JWT token. Returns payload or None."""
+        try:
+            return jwt.decode(
+                token,
+                self._settings.jwt_secret_key,
+                algorithms=[self._settings.jwt_algorithm],
+            )
+        except JWTError:
+            return None
+
+    # --- Database Operations (internal) ---
+
+    async def _get_user_by_email(self, email: str) -> User | None:
+        """Get user by email address."""
+        result = await self._db.execute(select(User).where(User.email == email))
+        return result.scalar_one_or_none()
+
+    async def _get_user_by_id(self, user_id: str) -> User | None:
+        """Get user by ID."""
+        result = await self._db.execute(select(User).where(User.id == user_id))
+        return result.scalar_one_or_none()
+
+    def _user_to_info(self, user: User) -> UserInfo:
+        """Convert User model to UserInfo."""
+        return UserInfo(
+            local_user_id=user.id,
+            email=user.email,
+            is_active=user.is_active,
+            provider="local",
+            external_id=None,
+        )
+
+    # --- AuthProvider Interface Implementation ---
+
+    async def register(
+        self,
+        email: str,
+        password: str,
+    ) -> UserInfo | AuthError:
+        """Register a new user with email and password."""
+        # Check if email already exists
+        existing = await self._get_user_by_email(email)
+        if existing:
+            return AuthError(
+                code=AuthErrorCode.EMAIL_EXISTS,
+                message="Email already registered",
+            )
+
+        # Create user with hashed password
+        password_hash = self._hash_password(password)
+        user = User(email=email, password_hash=password_hash)
+        self._db.add(user)
+        await self._db.commit()
+        await self._db.refresh(user)
+
+        return self._user_to_info(user)
+
+    async def login(
+        self,
+        email: str,
+        password: str,
+    ) -> tuple[UserInfo, TokenPair] | AuthError:
+        """Authenticate user and return tokens."""
+        user = await self._get_user_by_email(email)
+
+        if user is None:
+            # Run hash anyway to prevent timing attacks (user enumeration)
+            self._hash_password(password)
+            return AuthError(
+                code=AuthErrorCode.INVALID_CREDENTIALS,
+                message="Invalid email or password",
+            )
+
+        if not self._verify_password(password, user.password_hash):
+            return AuthError(
+                code=AuthErrorCode.INVALID_CREDENTIALS,
+                message="Invalid email or password",
+            )
+
+        if not user.is_active:
+            return AuthError(
+                code=AuthErrorCode.USER_INACTIVE,
+                message="User account is inactive",
+            )
+
+        access_token = self._create_access_token(user.id)
+        token_pair = TokenPair(
+            access_token=access_token,
+            refresh_token=None,  # Local provider doesn't use refresh tokens
+            expires_in=self._settings.jwt_expire_minutes * 60,
+        )
+
+        return (self._user_to_info(user), token_pair)
+
+    async def verify_token(
+        self,
+        token: str,
+    ) -> UserInfo | AuthError:
+        """Verify access token and return user info."""
+        payload = self._decode_token(token)
+        if payload is None:
+            return AuthError(
+                code=AuthErrorCode.INVALID_TOKEN,
+                message="Invalid or expired token",
+            )
+
+        user_id = payload.get("sub")
+        if user_id is None:
+            return AuthError(
+                code=AuthErrorCode.INVALID_TOKEN,
+                message="Token missing user ID",
+            )
+
+        user = await self._get_user_by_id(user_id)
+        if user is None:
+            return AuthError(
+                code=AuthErrorCode.USER_NOT_FOUND,
+                message="User not found",
+            )
+
+        if not user.is_active:
+            return AuthError(
+                code=AuthErrorCode.USER_INACTIVE,
+                message="User account is inactive",
+            )
+
+        return self._user_to_info(user)
+
+    async def refresh_token(
+        self,
+        refresh_token: str,
+    ) -> TokenPair | AuthError:
+        """Refresh tokens - not supported by local provider.
+
+        Local provider uses long-lived JWTs (24h) without refresh tokens.
+        Clients should re-authenticate when token expires.
+        """
+        return AuthError(
+            code=AuthErrorCode.PROVIDER_ERROR,
+            message="Token refresh not supported by local provider",
+        )
+
+    async def request_password_reset(
+        self,
+        email: str,
+    ) -> bool:
+        """Request password reset - not supported by local provider.
+
+        Local provider doesn't have email sending capability.
+        Returns True to not reveal if email exists.
+        """
+        # For security, always return True (don't reveal if email exists)
+        # Log for debugging but don't send email
+        return True

--- a/backend/app/services/auth/supabase.py
+++ b/backend/app/services/auth/supabase.py
@@ -1,0 +1,303 @@
+"""Supabase authentication provider.
+
+This provider integrates with Supabase Auth for user management while
+syncing users to the local database for FK relationships with images.
+"""
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from supabase import Client, create_client
+from supabase.lib.client_options import ClientOptions
+
+from app.config import Settings
+from app.models.user import User
+from app.services.auth.base import (
+    AuthError,
+    AuthErrorCode,
+    AuthProvider,
+    TokenPair,
+    UserInfo,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseAuthProvider(AuthProvider):
+    """Supabase authentication provider with local DB sync.
+
+    Uses Supabase for auth operations (register, login, password reset)
+    and syncs users to local DB on successful authentication.
+
+    Sync-on-auth strategy:
+    1. User authenticates with Supabase
+    2. On success, find or create local user by supabase_id or email
+    3. Return local user.id for FK relationships
+    """
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        settings: Settings,
+    ):
+        self._db = db
+        self._settings = settings
+
+        # Validate required settings
+        if not settings.supabase_url:
+            raise ValueError("SUPABASE_URL is required for Supabase auth provider")
+        if not settings.supabase_anon_key:
+            raise ValueError("SUPABASE_ANON_KEY is required for Supabase auth provider")
+
+        # Initialize Supabase client
+        options = ClientOptions(
+            auto_refresh_token=True,
+            persist_session=False,  # Server-side, no session persistence
+        )
+        self._client: Client = create_client(
+            settings.supabase_url,
+            settings.supabase_anon_key,
+            options=options,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "supabase"
+
+    # --- Local DB Sync Operations ---
+
+    async def _find_or_create_local_user(
+        self,
+        supabase_id: str,
+        email: str,
+    ) -> User:
+        """Find or create local user for Supabase user.
+
+        Sync strategy:
+        1. If supabase_id exists in local DB → return that user
+        2. If email exists → link to Supabase (migration path)
+        3. Otherwise → create new local user
+        """
+        # Try to find by supabase_id first (fastest path)
+        result = await self._db.execute(select(User).where(User.supabase_id == supabase_id))
+        user = result.scalar_one_or_none()
+        if user:
+            return user
+
+        # Try to find by email (migration path: local user → Supabase)
+        result = await self._db.execute(select(User).where(User.email == email))
+        user = result.scalar_one_or_none()
+        if user:
+            # Link existing local user to Supabase
+            user.supabase_id = supabase_id
+            await self._db.commit()
+            await self._db.refresh(user)
+            logger.info(f"Linked existing user {user.id} to Supabase ID {supabase_id}")
+            return user
+
+        # Create new local user (no password_hash for Supabase users)
+        user = User(
+            email=email,
+            password_hash=None,  # Supabase handles auth
+            supabase_id=supabase_id,
+        )
+        self._db.add(user)
+        await self._db.commit()
+        await self._db.refresh(user)
+        logger.info(f"Created new local user {user.id} for Supabase ID {supabase_id}")
+        return user
+
+    def _user_to_info(self, user: User) -> UserInfo:
+        """Convert User model to UserInfo."""
+        return UserInfo(
+            local_user_id=user.id,
+            email=user.email,
+            is_active=user.is_active,
+            provider="supabase",
+            external_id=user.supabase_id,
+        )
+
+    # --- AuthProvider Interface Implementation ---
+
+    async def register(
+        self,
+        email: str,
+        password: str,
+    ) -> UserInfo | AuthError:
+        """Register a new user with Supabase."""
+        try:
+            response = self._client.auth.sign_up(
+                {
+                    "email": email,
+                    "password": password,
+                }
+            )
+
+            if response.user is None:
+                return AuthError(
+                    code=AuthErrorCode.PROVIDER_ERROR,
+                    message="Registration failed - no user returned",
+                )
+
+            # Sync to local DB
+            user = await self._find_or_create_local_user(
+                supabase_id=response.user.id,
+                email=email,
+            )
+
+            return self._user_to_info(user)
+
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "already registered" in error_msg or "already exists" in error_msg:
+                return AuthError(
+                    code=AuthErrorCode.EMAIL_EXISTS,
+                    message="Email already registered",
+                )
+            logger.exception("Supabase registration error")
+            return AuthError(
+                code=AuthErrorCode.PROVIDER_ERROR,
+                message=f"Registration failed: {e!s}",
+            )
+
+    async def login(
+        self,
+        email: str,
+        password: str,
+    ) -> tuple[UserInfo, TokenPair] | AuthError:
+        """Authenticate user with Supabase."""
+        try:
+            response = self._client.auth.sign_in_with_password(
+                {
+                    "email": email,
+                    "password": password,
+                }
+            )
+
+            if response.user is None or response.session is None:
+                return AuthError(
+                    code=AuthErrorCode.INVALID_CREDENTIALS,
+                    message="Invalid email or password",
+                )
+
+            # Sync to local DB
+            user = await self._find_or_create_local_user(
+                supabase_id=response.user.id,
+                email=email,
+            )
+
+            if not user.is_active:
+                return AuthError(
+                    code=AuthErrorCode.USER_INACTIVE,
+                    message="User account is inactive",
+                )
+
+            token_pair = TokenPair(
+                access_token=response.session.access_token,
+                refresh_token=response.session.refresh_token,
+                expires_in=response.session.expires_in,
+            )
+
+            return (self._user_to_info(user), token_pair)
+
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "invalid" in error_msg or "credentials" in error_msg:
+                return AuthError(
+                    code=AuthErrorCode.INVALID_CREDENTIALS,
+                    message="Invalid email or password",
+                )
+            logger.exception("Supabase login error")
+            return AuthError(
+                code=AuthErrorCode.PROVIDER_ERROR,
+                message=f"Login failed: {e!s}",
+            )
+
+    async def verify_token(
+        self,
+        token: str,
+    ) -> UserInfo | AuthError:
+        """Verify Supabase access token."""
+        try:
+            response = self._client.auth.get_user(token)
+
+            if response.user is None:
+                return AuthError(
+                    code=AuthErrorCode.INVALID_TOKEN,
+                    message="Invalid or expired token",
+                )
+
+            # Find local user by supabase_id
+            result = await self._db.execute(
+                select(User).where(User.supabase_id == response.user.id)
+            )
+            user = result.scalar_one_or_none()
+
+            if user is None:
+                # User exists in Supabase but not locally - create them
+                user = await self._find_or_create_local_user(
+                    supabase_id=response.user.id,
+                    email=response.user.email or "",
+                )
+
+            if not user.is_active:
+                return AuthError(
+                    code=AuthErrorCode.USER_INACTIVE,
+                    message="User account is inactive",
+                )
+
+            return self._user_to_info(user)
+
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "invalid" in error_msg or "expired" in error_msg:
+                return AuthError(
+                    code=AuthErrorCode.INVALID_TOKEN,
+                    message="Invalid or expired token",
+                )
+            logger.exception("Supabase token verification error")
+            return AuthError(
+                code=AuthErrorCode.PROVIDER_ERROR,
+                message=f"Token verification failed: {e!s}",
+            )
+
+    async def refresh_token(
+        self,
+        refresh_token: str,
+    ) -> TokenPair | AuthError:
+        """Refresh Supabase access token."""
+        try:
+            response = self._client.auth.refresh_session(refresh_token)
+
+            if response.session is None:
+                return AuthError(
+                    code=AuthErrorCode.INVALID_TOKEN,
+                    message="Invalid refresh token",
+                )
+
+            return TokenPair(
+                access_token=response.session.access_token,
+                refresh_token=response.session.refresh_token,
+                expires_in=response.session.expires_in,
+            )
+
+        except Exception as e:
+            logger.exception("Supabase token refresh error")
+            return AuthError(
+                code=AuthErrorCode.PROVIDER_ERROR,
+                message=f"Token refresh failed: {e!s}",
+            )
+
+    async def request_password_reset(
+        self,
+        email: str,
+    ) -> bool:
+        """Request password reset email from Supabase."""
+        try:
+            self._client.auth.reset_password_email(email)
+            return True
+        except Exception as e:
+            # Log but don't expose errors (security: don't reveal if email exists)
+            logger.warning(f"Password reset request failed: {e}")
+            return True  # Always return True to prevent email enumeration

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "email-validator>=2.3.0",
     # Phase 3: Web UI
     "jinja2>=3.1.0",
-    "itsdangerous>=2.2.0",  # For CSRF tokens
+    "itsdangerous>=2.2.0", # For CSRF tokens
+    "supabase>=2.27.1",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -190,3 +190,41 @@ class TestTokenEndpoint:
         )
 
         assert response.status_code == 401
+
+
+class TestPasswordReset:
+    """Test password reset endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_password_reset_returns_202(self, client: AsyncClient):
+        """Password reset request always returns 202 (prevents email enumeration)."""
+        response = await client.post(
+            "/api/v1/auth/password-reset",
+            json={"email": "test@example.com"},
+        )
+
+        assert response.status_code == 202
+        data = response.json()
+        assert "message" in data
+        assert "password reset" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_password_reset_nonexistent_email(self, client: AsyncClient):
+        """Nonexistent email still returns 202 (security: no enumeration)."""
+        response = await client.post(
+            "/api/v1/auth/password-reset",
+            json={"email": "nonexistent@example.com"},
+        )
+
+        # Should return same response as existing email
+        assert response.status_code == 202
+
+    @pytest.mark.asyncio
+    async def test_password_reset_invalid_email(self, client: AsyncClient):
+        """Invalid email format returns 422."""
+        response = await client.post(
+            "/api/v1/auth/password-reset",
+            json={"email": "not-an-email"},
+        )
+
+        assert response.status_code == 422

--- a/backend/tests/unit/test_auth_providers.py
+++ b/backend/tests/unit/test_auth_providers.py
@@ -1,0 +1,244 @@
+"""Unit tests for auth provider implementations."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.auth.base import AuthError, AuthErrorCode, TokenPair, UserInfo
+from app.services.auth.factory import create_auth_provider
+from app.services.auth.local import LocalAuthProvider
+
+
+class TestLocalAuthProvider:
+    """Tests for LocalAuthProvider."""
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Create mock settings."""
+        settings = MagicMock()
+        settings.jwt_secret_key = "test-secret-key-for-testing"
+        settings.jwt_algorithm = "HS256"
+        settings.jwt_expire_minutes = 60
+        settings.auth_provider = "local"
+        return settings
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create mock database session."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def provider(self, mock_db, mock_settings):
+        """Create LocalAuthProvider instance."""
+        return LocalAuthProvider(db=mock_db, settings=mock_settings)
+
+    def test_provider_name(self, provider):
+        """Test provider name is 'local'."""
+        assert provider.provider_name == "local"
+
+    def test_hash_password_returns_different_hash(self, provider):
+        """Test password hashing returns different hash each time (due to salt)."""
+        password = "testpassword123"
+        hash1 = provider._hash_password(password)
+        hash2 = provider._hash_password(password)
+
+        assert hash1 != hash2  # Different salts
+        assert hash1.startswith("$2b$")  # bcrypt format
+
+    def test_verify_password_correct(self, provider):
+        """Test password verification with correct password."""
+        password = "testpassword123"
+        hashed = provider._hash_password(password)
+
+        assert provider._verify_password(password, hashed) is True
+
+    def test_verify_password_incorrect(self, provider):
+        """Test password verification with incorrect password."""
+        password = "testpassword123"
+        wrong_password = "wrongpassword"
+        hashed = provider._hash_password(password)
+
+        assert provider._verify_password(wrong_password, hashed) is False
+
+    def test_verify_password_invalid_hash(self, provider):
+        """Test password verification with invalid hash returns False."""
+        assert provider._verify_password("password", "invalid-hash") is False
+
+    def test_create_access_token(self, provider):
+        """Test JWT token creation."""
+        user_id = "test-user-id"
+        token = provider._create_access_token(user_id)
+
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_decode_token_valid(self, provider):
+        """Test decoding a valid token."""
+        user_id = "test-user-id"
+        token = provider._create_access_token(user_id)
+        payload = provider._decode_token(token)
+
+        assert payload is not None
+        assert payload["sub"] == user_id
+        assert payload["provider"] == "local"
+
+    def test_decode_token_invalid(self, provider):
+        """Test decoding an invalid token returns None."""
+        payload = provider._decode_token("invalid-token")
+        assert payload is None
+
+    def test_decode_token_wrong_secret(self, provider, mock_db):
+        """Test decoding token with wrong secret returns None."""
+        user_id = "test-user-id"
+        token = provider._create_access_token(user_id)
+
+        # Create provider with different secret
+        other_settings = MagicMock()
+        other_settings.jwt_secret_key = "different-secret"
+        other_settings.jwt_algorithm = "HS256"
+        other_provider = LocalAuthProvider(db=mock_db, settings=other_settings)
+
+        payload = other_provider._decode_token(token)
+        assert payload is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_not_supported(self, provider):
+        """Test refresh token returns error for local provider."""
+        result = await provider.refresh_token("some-refresh-token")
+
+        assert isinstance(result, AuthError)
+        assert result.code == AuthErrorCode.PROVIDER_ERROR
+        assert "not supported" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_request_password_reset_returns_true(self, provider):
+        """Test password reset always returns True (security: no email enumeration)."""
+        result = await provider.request_password_reset("test@example.com")
+        assert result is True
+
+        result = await provider.request_password_reset("nonexistent@example.com")
+        assert result is True
+
+
+class TestAuthProviderFactory:
+    """Tests for auth provider factory."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create mock database session."""
+        return AsyncMock()
+
+    def test_create_local_provider(self, mock_db):
+        """Test factory creates LocalAuthProvider for 'local' setting."""
+        settings = MagicMock()
+        settings.auth_provider = "local"
+        settings.jwt_secret_key = "test-secret"
+        settings.jwt_algorithm = "HS256"
+        settings.jwt_expire_minutes = 60
+
+        provider = create_auth_provider(db=mock_db, settings=settings)
+
+        assert isinstance(provider, LocalAuthProvider)
+        assert provider.provider_name == "local"
+
+    def test_create_provider_invalid_type(self, mock_db):
+        """Test factory raises error for unknown provider type."""
+        settings = MagicMock()
+        settings.auth_provider = "unknown-provider"
+
+        with pytest.raises(ValueError, match="Unknown auth provider"):
+            create_auth_provider(db=mock_db, settings=settings)
+
+    def test_create_supabase_provider_missing_config(self, mock_db):
+        """Test factory raises error when Supabase config is missing."""
+        settings = MagicMock()
+        settings.auth_provider = "supabase"
+        settings.supabase_url = None
+        settings.supabase_anon_key = None
+
+        with pytest.raises(ValueError, match="SUPABASE_URL is required"):
+            create_auth_provider(db=mock_db, settings=settings)
+
+
+class TestAuthError:
+    """Tests for AuthError dataclass."""
+
+    def test_to_dict(self):
+        """Test AuthError converts to dictionary correctly."""
+        error = AuthError(
+            code=AuthErrorCode.INVALID_CREDENTIALS,
+            message="Invalid email or password",
+        )
+        result = error.to_dict()
+
+        assert result == {
+            "code": "INVALID_CREDENTIALS",
+            "message": "Invalid email or password",
+        }
+
+    def test_immutable(self):
+        """Test AuthError is immutable (frozen dataclass)."""
+        error = AuthError(
+            code=AuthErrorCode.EMAIL_EXISTS,
+            message="Email already registered",
+        )
+
+        with pytest.raises(AttributeError):
+            error.code = AuthErrorCode.INVALID_TOKEN
+
+
+class TestUserInfo:
+    """Tests for UserInfo dataclass."""
+
+    def test_create_local_user_info(self):
+        """Test creating UserInfo for local user."""
+        info = UserInfo(
+            local_user_id="user-123",
+            email="test@example.com",
+            is_active=True,
+            provider="local",
+        )
+
+        assert info.local_user_id == "user-123"
+        assert info.email == "test@example.com"
+        assert info.is_active is True
+        assert info.provider == "local"
+        assert info.external_id is None
+
+    def test_create_supabase_user_info(self):
+        """Test creating UserInfo for Supabase user."""
+        info = UserInfo(
+            local_user_id="user-123",
+            email="test@example.com",
+            is_active=True,
+            provider="supabase",
+            external_id="supabase-uuid-456",
+        )
+
+        assert info.local_user_id == "user-123"
+        assert info.provider == "supabase"
+        assert info.external_id == "supabase-uuid-456"
+
+
+class TestTokenPair:
+    """Tests for TokenPair dataclass."""
+
+    def test_access_token_only(self):
+        """Test TokenPair with access token only."""
+        pair = TokenPair(access_token="access-token-123")
+
+        assert pair.access_token == "access-token-123"
+        assert pair.refresh_token is None
+        assert pair.expires_in is None
+
+    def test_full_token_pair(self):
+        """Test TokenPair with all fields."""
+        pair = TokenPair(
+            access_token="access-token-123",
+            refresh_token="refresh-token-456",
+            expires_in=3600,
+        )
+
+        assert pair.access_token == "access-token-123"
+        assert pair.refresh_token == "refresh-token-456"
+        assert pair.expires_in == 3600


### PR DESCRIPTION
## Summary

Implements the Pluggable Authentication System (Phase 3.5) using the Strategy Pattern:

- **AuthProvider Interface**: Abstract base class with 5 core methods (`register`, `login`, `verify_token`, `refresh_token`, `request_password_reset`)
- **LocalAuthProvider**: Wraps existing bcrypt + JWT authentication (default)
- **SupabaseAuthProvider**: Integrates Supabase Auth with sync-on-auth to local DB for FK relationships
- **Factory Pattern**: `create_auth_provider()` instantiates provider based on `AUTH_PROVIDER` setting
- **Password Reset**: New `/api/v1/auth/password-reset` endpoint
- **Database Migration**: Adds `supabase_id` column, makes `password_hash` nullable for Supabase users

## Configuration

| Setting | Values | Default |
|---------|--------|---------|
| `AUTH_PROVIDER` | `local`, `supabase` | `local` |
| `SUPABASE_URL` | URL | Required for Supabase |
| `SUPABASE_ANON_KEY` | Key | Required for Supabase |

## Test Results

- **222 tests passing** (23 new tests added)
- 26 skipped (existing integration tests)
- All pre-commit hooks passing

## Architecture

```
AuthProvider (ABC)
├── LocalAuthProvider (bcrypt + JWT)
└── SupabaseAuthProvider (Supabase SDK + local DB sync)
```

Mirrors the existing `StorageBackend` pattern used for storage abstraction.

## Related

- Phase 3.5 (Pluggable Auth)
- PRD: `docs/prd/prd-pluggable-auth-system.md`
- Design Doc: `docs/design/design-pluggable-auth-system.md`
- PR #30 (documentation)

## Backward Compatibility

- Existing deployments continue using local auth unchanged
- No changes required to existing configuration
- Migration adds nullable column (no data loss)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)