### PR TITLE
feat(deploy): add Supabase auth env vars to docker-compose

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,10 @@ Both are explicit, visible, and testable.
 
 import io
 import os
+
+# Force local auth provider for tests (before any app imports)
+# This ensures tests don't accidentally use Supabase even if .env has AUTH_PROVIDER=supabase
+os.environ["AUTH_PROVIDER"] = "local"
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from pathlib import Path

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -64,6 +64,11 @@ services:
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-dev-secret-change-in-production}
       JWT_ACCESS_TOKEN_EXPIRE_MINUTES: ${JWT_ACCESS_TOKEN_EXPIRE_MINUTES:-1440}
 
+      # Auth Provider (Phase 3.5)
+      AUTH_PROVIDER: ${AUTH_PROVIDER:-local}
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-}
+
       # App Settings
       DEBUG: ${DEBUG:-false}
     depends_on:


### PR DESCRIPTION
## Summary
- Add AUTH_PROVIDER, SUPABASE_URL, SUPABASE_ANON_KEY environment variables to the app service in docker-compose.yml
- Force AUTH_PROVIDER=local in test conftest.py to prevent Supabase client initialization during tests
- Defaults to local auth if environment variables are not provided

## Why
The Phase 3.5 Supabase auth integration was merged, but the docker-compose.yml was missing the environment variable mappings. This prevented the Supabase configuration from reaching the container.

## Test Results
- 222 tests passing
- Tests remain isolated using local auth provider

## Related
- Phase 3.5: Supabase Authentication
- Follows PR #31 and #32

---