### PR TITLE
fix: Supabase client compatibility for v2.x

### DIFF
--- a/backend/app/services/auth/supabase.py
+++ b/backend/app/services/auth/supabase.py
@@ -9,7 +9,6 @@ import logging
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from supabase import Client, create_client
-from supabase.lib.client_options import ClientOptions
 
 from app.config import Settings
 from app.models.user import User
@@ -50,15 +49,10 @@ class SupabaseAuthProvider(AuthProvider):
         if not settings.supabase_anon_key:
             raise ValueError("SUPABASE_ANON_KEY is required for Supabase auth provider")
 
-        # Initialize Supabase client
-        options = ClientOptions(
-            auto_refresh_token=True,
-            persist_session=False,  # Server-side, no session persistence
-        )
+        # Initialize Supabase client (using defaults - no session persistence needed server-side)
         self._client: Client = create_client(
             settings.supabase_url,
             settings.supabase_anon_key,
-            options=options,
         )
 
     @property


### PR DESCRIPTION
## Summary
- Remove incompatible `ClientOptions` import and usage from Supabase client initialization
- The supabase v2.x library changed the API - `ClientOptions` no longer has a `storage` attribute
- Simplified initialization to use library defaults (works fine for server-side usage)

## Test Results
- 222 tests passing
- Fix verified locally

## Related
- Fixes production deployment error: `AttributeError: 'ClientOptions' object has no attribute 'storage'`
- Part of Phase 3.5 Supabase auth deployment

---
Generated with [Claude Code](https://claude.com/claude-code)