### PR TITLE
fix(auth): use pluggable auth provider for web cookie verification

### DIFF
--- a/backend/tests/unit/test_web_auth.py
+++ b/backend/tests/unit/test_web_auth.py
@@ -1,4 +1,8 @@
-"""Unit tests for web authentication (cookie-based auth)."""
+"""Unit tests for web authentication (cookie-based auth).
+
+Tests the get_current_user_from_cookie dependency which uses the pluggable
+auth provider pattern for token verification.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -6,6 +10,7 @@ import pytest
 
 from app.api.web import AUTH_COOKIE_NAME, get_current_user_from_cookie
 from app.models.user import User
+from app.services.auth.base import AuthError, AuthErrorCode, UserInfo
 
 
 class TestGetCurrentUserFromCookie:
@@ -30,14 +35,24 @@ class TestGetCurrentUserFromCookie:
         request.cookies.get.return_value = "invalid.token.here"
         db = AsyncMock()
 
-        with patch("app.api.web.AuthService") as mock_auth_service:
-            mock_auth = mock_auth_service.return_value
-            mock_auth.verify_token.return_value = None
+        with (
+            patch("app.api.web.get_settings") as mock_get_settings,
+            patch("app.api.web.create_auth_provider") as mock_create_provider,
+        ):
+            mock_settings = MagicMock()
+            mock_get_settings.return_value = mock_settings
+
+            mock_provider = AsyncMock()
+            mock_provider.verify_token.return_value = AuthError(
+                code=AuthErrorCode.INVALID_TOKEN,
+                message="Invalid token",
+            )
+            mock_create_provider.return_value = mock_provider
 
             result = await get_current_user_from_cookie(request, db)
 
         assert result is None
-        mock_auth.verify_token.assert_called_once_with("invalid.token.here")
+        mock_provider.verify_token.assert_called_once_with("invalid.token.here")
 
     @pytest.mark.asyncio
     async def test_returns_none_when_user_not_found(self):
@@ -46,15 +61,30 @@ class TestGetCurrentUserFromCookie:
         request.cookies.get.return_value = "valid.token"
         db = AsyncMock()
 
-        with patch("app.api.web.AuthService") as mock_auth_service:
-            mock_auth = mock_auth_service.return_value
-            mock_auth.verify_token.return_value = "user-123"
-            mock_auth.get_user_by_id = AsyncMock(return_value=None)
+        # Mock the database query to return None (user not found)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db.execute.return_value = mock_result
+
+        with (
+            patch("app.api.web.get_settings") as mock_get_settings,
+            patch("app.api.web.create_auth_provider") as mock_create_provider,
+        ):
+            mock_settings = MagicMock()
+            mock_get_settings.return_value = mock_settings
+
+            mock_provider = AsyncMock()
+            mock_provider.verify_token.return_value = UserInfo(
+                local_user_id="user-123",
+                email="test@example.com",
+                is_active=True,
+                provider="local",
+            )
+            mock_create_provider.return_value = mock_provider
 
             result = await get_current_user_from_cookie(request, db)
 
         assert result is None
-        mock_auth.get_user_by_id.assert_called_once_with("user-123")
 
     @pytest.mark.asyncio
     async def test_returns_none_when_user_inactive(self):
@@ -63,13 +93,30 @@ class TestGetCurrentUserFromCookie:
         request.cookies.get.return_value = "valid.token"
         db = AsyncMock()
 
+        # Create an inactive user
         inactive_user = MagicMock(spec=User)
         inactive_user.is_active = False
 
-        with patch("app.api.web.AuthService") as mock_auth_service:
-            mock_auth = mock_auth_service.return_value
-            mock_auth.verify_token.return_value = "user-123"
-            mock_auth.get_user_by_id = AsyncMock(return_value=inactive_user)
+        # Mock the database query to return the inactive user
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = inactive_user
+        db.execute.return_value = mock_result
+
+        with (
+            patch("app.api.web.get_settings") as mock_get_settings,
+            patch("app.api.web.create_auth_provider") as mock_create_provider,
+        ):
+            mock_settings = MagicMock()
+            mock_get_settings.return_value = mock_settings
+
+            mock_provider = AsyncMock()
+            mock_provider.verify_token.return_value = UserInfo(
+                local_user_id="user-123",
+                email="test@example.com",
+                is_active=True,  # Provider says active, but DB user is inactive
+                provider="local",
+            )
+            mock_create_provider.return_value = mock_provider
 
             result = await get_current_user_from_cookie(request, db)
 
@@ -82,15 +129,32 @@ class TestGetCurrentUserFromCookie:
         request.cookies.get.return_value = "valid.jwt.token"
         db = AsyncMock()
 
+        # Create an active user
         active_user = MagicMock(spec=User)
         active_user.is_active = True
         active_user.id = "user-123"
         active_user.email = "test@example.com"
 
-        with patch("app.api.web.AuthService") as mock_auth_service:
-            mock_auth = mock_auth_service.return_value
-            mock_auth.verify_token.return_value = "user-123"
-            mock_auth.get_user_by_id = AsyncMock(return_value=active_user)
+        # Mock the database query to return the active user
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = active_user
+        db.execute.return_value = mock_result
+
+        with (
+            patch("app.api.web.get_settings") as mock_get_settings,
+            patch("app.api.web.create_auth_provider") as mock_create_provider,
+        ):
+            mock_settings = MagicMock()
+            mock_get_settings.return_value = mock_settings
+
+            mock_provider = AsyncMock()
+            mock_provider.verify_token.return_value = UserInfo(
+                local_user_id="user-123",
+                email="test@example.com",
+                is_active=True,
+                provider="local",
+            )
+            mock_create_provider.return_value = mock_provider
 
             result = await get_current_user_from_cookie(request, db)
 
@@ -109,3 +173,46 @@ class TestGetCurrentUserFromCookie:
         await get_current_user_from_cookie(request, db)
 
         request.cookies.get.assert_called_with("chitram_auth")
+
+    @pytest.mark.asyncio
+    async def test_works_with_supabase_provider(self):
+        """Should work with Supabase provider tokens."""
+        request = MagicMock()
+        request.cookies.get.return_value = "supabase.jwt.token"
+        db = AsyncMock()
+
+        # Create an active user with supabase_id
+        active_user = MagicMock(spec=User)
+        active_user.is_active = True
+        active_user.id = "local-user-123"
+        active_user.email = "test@example.com"
+        active_user.supabase_id = "supabase-user-456"
+
+        # Mock the database query to return the active user
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = active_user
+        db.execute.return_value = mock_result
+
+        with (
+            patch("app.api.web.get_settings") as mock_get_settings,
+            patch("app.api.web.create_auth_provider") as mock_create_provider,
+        ):
+            mock_settings = MagicMock()
+            mock_settings.auth_provider = "supabase"
+            mock_get_settings.return_value = mock_settings
+
+            mock_provider = AsyncMock()
+            mock_provider.verify_token.return_value = UserInfo(
+                local_user_id="local-user-123",
+                email="test@example.com",
+                is_active=True,
+                provider="supabase",
+                external_id="supabase-user-456",
+            )
+            mock_create_provider.return_value = mock_provider
+
+            result = await get_current_user_from_cookie(request, db)
+
+        assert result is active_user
+        assert result.id == "local-user-123"
+        mock_create_provider.assert_called_once_with(db=db, settings=mock_settings)


### PR DESCRIPTION
## Summary
- Fix web UI navigation not showing logged-in state after Supabase authentication
- Replace `AuthService` with pluggable `create_auth_provider` in `get_current_user_from_cookie`
- Enable Supabase token verification for cookie-based web authentication
- Update unit tests to mock the pluggable auth provider pattern
- Add dedicated test for Supabase provider token verification

## Root Cause
The `get_current_user_from_cookie` function in `web.py` was using `AuthService.verify_token()` which only verifies local JWTs signed with `JWT_SECRET_KEY`. When Supabase auth is enabled, the cookie contains a Supabase JWT signed with Supabase's secret, causing verification to fail silently and the nav bar to always show Login/Register.

## Test Results
- 223 tests passing
- Added 1 new test for Supabase provider verification

## Related
- Phase 3.5 - Supabase Authentication
- Fixes nav bar UX bug reported after Supabase deployment

---
Generated with [Claude Code](https://claude.com/claude-code)