### PR TITLE
fix(security): enforce private gallery per FR-4.1 unlisted model

### DIFF
--- a/backend/app/services/image_service.py
+++ b/backend/app/services/image_service.py
@@ -159,18 +159,24 @@ class ImageService:
         )
         return list(result.scalars().all())
 
-    async def list_by_user(self, user_id: str) -> list[Image]:
+    async def list_by_user(self, user_id: str, limit: int = 100, offset: int = 0) -> list[Image]:
         """
-        List all images uploaded by a specific user.
+        List images uploaded by a specific user with pagination.
 
         Args:
             user_id: User ID to filter by
+            limit: Maximum number of images to return (default 100)
+            offset: Number of images to skip (default 0)
 
         Returns:
             List of Image models ordered by creation date (newest first)
         """
         result = await self.db.execute(
-            select(Image).where(Image.user_id == user_id).order_by(desc(Image.created_at))
+            select(Image)
+            .where(Image.user_id == user_id)
+            .order_by(desc(Image.created_at))
+            .limit(limit)
+            .offset(offset)
         )
         return list(result.scalars().all())
 


### PR DESCRIPTION
## Summary

**SECURITY FIX**: Home page was publicly displaying ALL users' images, violating FR-4.1.

- Home page (`/`) now requires authentication and redirects anonymous users to `/login`
- Authenticated users only see their own images on the home page
- Gallery partial (`/partials/gallery`) returns empty list for unauthenticated users
- Added pagination support (limit/offset) to `list_by_user()` service method
- Updated integration tests to verify private gallery behavior
- Added `TestPrivateGallery` unit tests for FR-4.1 compliance

### FR-4.1 Compliance

Per FR-4.1: *"System shall NOT provide a public listing of all images. Images are unlisted - accessible only by direct URL or from owner's gallery."*

**Before:** Anonymous users could see ALL images from ALL users on the home page.
**After:** Anonymous users are redirected to login; authenticated users see only their own images.

Note: Direct URL access (`/image/{id}`) remains public per the "unlisted model" design.

## Test Results

- 229 tests passing
- 26 skipped (Redis/MinIO integration tests)
- Added 5 new FR-4.1 compliance tests

## Related

- Resolves security issue reported post-Supabase integration
- Related to PR #36 (auth provider fix)
- See `docs/retrospectives/2026-01-08-supabase-nav-auth-bug.md` for context

---
Generated with [Claude Code](https://claude.com/claude-code)