### PR TITLE
feat: add GitHub OAuth login via Supabase

### DIFF
--- a/backend/app/templates/auth_callback.html
+++ b/backend/app/templates/auth_callback.html
@@ -1,0 +1,109 @@
+{% extends "base.html" %}
+
+{% block title %}Authenticating...{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto text-center">
+    <div class="bg-white rounded-2xl shadow-sm border border-cream-300 p-8">
+        <!-- Loading State -->
+        <div id="loading-state">
+            <svg class="animate-spin h-12 w-12 mx-auto text-terracotta-500 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            <h2 class="font-display text-xl font-semibold text-gray-800 mb-2">
+                Completing sign in...
+            </h2>
+            <p class="text-gray-600">
+                Please wait while we finish authenticating you.
+            </p>
+        </div>
+
+        <!-- Error State (hidden by default) -->
+        <div id="error-state" class="hidden">
+            <svg class="h-12 w-12 mx-auto text-red-500 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <h2 class="font-display text-xl font-semibold text-gray-800 mb-2">
+                Authentication Failed
+            </h2>
+            <p id="error-message" class="text-gray-600 mb-4">
+                Something went wrong during sign in.
+            </p>
+            <a href="/login" class="inline-block bg-terracotta-500 text-white py-2 px-4 rounded-lg font-medium hover:bg-terracotta-600 transition-colors">
+                Try Again
+            </a>
+        </div>
+    </div>
+</div>
+
+<script>
+    // Extract token from URL hash and set cookie
+    async function handleCallback() {
+        const loadingState = document.getElementById('loading-state');
+        const errorState = document.getElementById('error-state');
+        const errorMessage = document.getElementById('error-message');
+
+        function showError(message) {
+            loadingState.classList.add('hidden');
+            errorState.classList.remove('hidden');
+            errorMessage.textContent = message;
+        }
+
+        try {
+            // Check if Supabase client is available
+            if (!window.supabase) {
+                showError('Authentication service not available');
+                return;
+            }
+
+            // Get session from Supabase (it handles the hash parsing)
+            const { data, error } = await window.supabase.auth.getSession();
+
+            if (error) {
+                showError(error.message);
+                return;
+            }
+
+            if (!data.session) {
+                // No session yet, try to exchange the code/token
+                // Supabase JS client should handle this automatically from URL hash
+                const hashParams = new URLSearchParams(window.location.hash.substring(1));
+                const accessToken = hashParams.get('access_token');
+
+                if (accessToken) {
+                    // Set the cookie with the access token
+                    document.cookie = `chitram_auth=${accessToken}; path=/; max-age=${60*60*24*7}; SameSite=Strict`;
+                    window.location.href = '/';
+                    return;
+                }
+
+                // Check URL params for error
+                const urlParams = new URLSearchParams(window.location.search);
+                const errorDesc = urlParams.get('error_description');
+                if (errorDesc) {
+                    showError(decodeURIComponent(errorDesc));
+                    return;
+                }
+
+                showError('No authentication data received');
+                return;
+            }
+
+            // We have a session - set the cookie
+            const accessToken = data.session.access_token;
+            document.cookie = `chitram_auth=${accessToken}; path=/; max-age=${60*60*24*7}; SameSite=Strict`;
+
+            // Redirect to home
+            window.location.href = '/';
+
+        } catch (err) {
+            console.error('Auth callback error:', err);
+            showError('An unexpected error occurred');
+        }
+    }
+
+    // Run on page load
+    handleCallback();
+</script>
+{% endblock %}

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -51,6 +51,18 @@
     <!-- HTMX -->
     <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 
+    <!-- Supabase JS Client (for OAuth) -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+        // Initialize Supabase client for OAuth (config injected from server)
+        window.SUPABASE_URL = '{{ supabase_url | default("") }}';
+        window.SUPABASE_ANON_KEY = '{{ supabase_anon_key | default("") }}';
+
+        if (window.SUPABASE_URL && window.SUPABASE_ANON_KEY) {
+            window.supabase = supabase.createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
+        }
+    </script>
+
     <!-- Custom Styles -->
     <style>
         /* Base styles */

--- a/backend/app/templates/login.html
+++ b/backend/app/templates/login.html
@@ -67,6 +67,31 @@
             </svg>
         </button>
 
+        {% if supabase_url %}
+        <!-- OAuth Divider -->
+        <div class="relative my-6">
+            <div class="absolute inset-0 flex items-center">
+                <div class="w-full border-t border-cream-300"></div>
+            </div>
+            <div class="relative flex justify-center text-sm">
+                <span class="px-2 bg-white text-gray-500">Or continue with</span>
+            </div>
+        </div>
+
+        <!-- GitHub OAuth Button -->
+        <button
+            type="button"
+            id="github-login-btn"
+            onclick="loginWithGitHub()"
+            class="w-full bg-gray-900 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-800 transition-colors flex items-center justify-center space-x-2"
+        >
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+            </svg>
+            <span>Continue with GitHub</span>
+        </button>
+        {% endif %}
+
         <!-- Register Link -->
         <p class="mt-6 text-center text-gray-600">
             Don't have an account?
@@ -129,6 +154,48 @@
         submitBtn.disabled = false;
         document.getElementById('submit-text').textContent = 'Login';
         document.getElementById('submit-spinner').classList.add('hidden');
+    }
+
+    // GitHub OAuth Login
+    async function loginWithGitHub() {
+        if (!window.supabase) {
+            showError('OAuth not configured');
+            return;
+        }
+
+        const btn = document.getElementById('github-login-btn');
+        btn.disabled = true;
+        btn.innerHTML = `
+            <svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            <span>Redirecting...</span>
+        `;
+
+        try {
+            const { data, error } = await window.supabase.auth.signInWithOAuth({
+                provider: 'github',
+                options: {
+                    redirectTo: window.location.origin + '/auth/callback'
+                }
+            });
+
+            if (error) {
+                showError(error.message);
+                btn.disabled = false;
+                btn.innerHTML = `
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                        <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                    </svg>
+                    <span>Continue with GitHub</span>
+                `;
+            }
+            // If successful, browser will redirect to GitHub
+        } catch (err) {
+            showError('Failed to connect to GitHub');
+            btn.disabled = false;
+        }
     }
 </script>
 {% endblock %}

--- a/backend/app/templates/register.html
+++ b/backend/app/templates/register.html
@@ -84,6 +84,31 @@
             </svg>
         </button>
 
+        {% if supabase_url %}
+        <!-- OAuth Divider -->
+        <div class="relative my-6">
+            <div class="absolute inset-0 flex items-center">
+                <div class="w-full border-t border-cream-300"></div>
+            </div>
+            <div class="relative flex justify-center text-sm">
+                <span class="px-2 bg-white text-gray-500">Or continue with</span>
+            </div>
+        </div>
+
+        <!-- GitHub OAuth Button -->
+        <button
+            type="button"
+            id="github-login-btn"
+            onclick="loginWithGitHub()"
+            class="w-full bg-gray-900 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-800 transition-colors flex items-center justify-center space-x-2"
+        >
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+            </svg>
+            <span>Continue with GitHub</span>
+        </button>
+        {% endif %}
+
         <!-- Login Link -->
         <p class="mt-6 text-center text-gray-600">
             Already have an account?
@@ -171,6 +196,48 @@
         submitBtn.disabled = false;
         document.getElementById('submit-text').textContent = 'Create Account';
         document.getElementById('submit-spinner').classList.add('hidden');
+    }
+
+    // GitHub OAuth Login
+    async function loginWithGitHub() {
+        if (!window.supabase) {
+            showError('OAuth not configured');
+            return;
+        }
+
+        const btn = document.getElementById('github-login-btn');
+        btn.disabled = true;
+        btn.innerHTML = `
+            <svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            <span>Redirecting...</span>
+        `;
+
+        try {
+            const { data, error } = await window.supabase.auth.signInWithOAuth({
+                provider: 'github',
+                options: {
+                    redirectTo: window.location.origin + '/auth/callback'
+                }
+            });
+
+            if (error) {
+                showError(error.message);
+                btn.disabled = false;
+                btn.innerHTML = `
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                        <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+                    </svg>
+                    <span>Continue with GitHub</span>
+                `;
+            }
+            // If successful, browser will redirect to GitHub
+        } catch (err) {
+            showError('Failed to connect to GitHub');
+            btn.disabled = false;
+        }
     }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add "Continue with GitHub" OAuth button to login and register pages
- Create `/auth/callback` route to handle Supabase OAuth redirect and token extraction
- Initialize Supabase JS client in base template for OAuth flow
- Existing email/password login remains unchanged

## Implementation
- Uses Supabase's built-in GitHub OAuth integration (no backend auth code changes)
- Frontend-only OAuth flow: Supabase JS handles redirect → GitHub → callback
- Token extracted from URL hash in `auth_callback.html` and stored as `chitram_auth` cookie
- GitHub button only renders when `supabase_url` is configured (i.e., AUTH_PROVIDER=supabase)

## Test plan
- [ ] Deploy to production (OAuth cannot be tested locally - needs real redirect URLs)
- [ ] Click "Continue with GitHub" on login page → redirects to GitHub
- [ ] Authorize app → redirects back to `/auth/callback` → redirects to home
- [ ] Verify nav shows user email and logout button
- [ ] Verify existing email/password login still works
- [ ] Test on register page as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)