### PR TITLE
security: add brute force protection and bot detection

### DIFF
--- a/backend/alembic/versions/sec01_add_user_lockout_fields.py
+++ b/backend/alembic/versions/sec01_add_user_lockout_fields.py
@@ -1,0 +1,52 @@
+"""add user lockout fields for brute force protection
+
+Phase Security: Add failed_login_attempts counter and locked_until timestamp
+for brute force protection. Accounts lock for 15 minutes after 5 failed attempts.
+
+Revision ID: sec01_user_lockout
+Revises: okr4l08scgm2
+Create Date: 2026-02-02 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "sec01_user_lockout"
+down_revision: str | Sequence[str] | None = "okr4l08scgm2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add brute force protection fields to users table."""
+    # Add failed_login_attempts counter
+    op.add_column(
+        "users",
+        sa.Column(
+            "failed_login_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+    # Add locked_until timestamp for account lockout
+    op.add_column(
+        "users",
+        sa.Column(
+            "locked_until",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove brute force protection fields from users table."""
+    op.drop_column("users", "locked_until")
+    op.drop_column("users", "failed_login_attempts")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -2,9 +2,16 @@
 
 This module provides the auth API using the pluggable AuthProvider interface.
 The actual provider (local, supabase, etc.) is determined by configuration.
+
+Security features:
+- Per-IP and per-email rate limiting on login/register (5 attempts/5min per email)
+- Honeypot field detection on registration (bot protection)
+- Account lockout after failed login attempts (handled by auth provider)
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -20,12 +27,64 @@ from app.schemas.auth import (
     UserRegister,
     UserResponse,
 )
-from app.schemas.error import ErrorDetail
-from app.services.auth import AuthError, AuthProvider, create_auth_provider
+from app.schemas.error import ErrorCodes, ErrorDetail
+from app.services.auth import AuthError, AuthErrorCode, AuthProvider, create_auth_provider
+from app.services.rate_limiter import RateLimiter
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token", auto_error=False)
+
+
+def get_rate_limiter(request: Request) -> RateLimiter | None:
+    """Dependency to get rate limiter from app state."""
+    return getattr(request.app.state, "rate_limiter", None)
+
+
+def get_client_ip(request: Request) -> str:
+    """Extract client IP from request (supports reverse proxy)."""
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+async def check_auth_rate_limit(
+    request: Request,
+    email: str | None = None,
+    rate_limiter: RateLimiter | None = Depends(get_rate_limiter),
+) -> None:
+    """
+    Check auth-specific rate limits (stricter than general limits).
+
+    Enforces:
+    - Per-IP: 20 requests per 5 minutes
+    - Per-email: 5 requests per 5 minutes (if email provided)
+
+    Raises HTTPException 429 if limit exceeded.
+    """
+    if not rate_limiter or not rate_limiter.enabled:
+        return
+
+    client_ip = get_client_ip(request)
+    result = await rate_limiter.check_auth(ip=client_ip, email=email)
+
+    if not result.allowed:
+        logger.warning(f"Auth rate limit exceeded - IP: {client_ip}, Email: {email or 'N/A'}")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ErrorDetail(
+                code=ErrorCodes.RATE_LIMIT_EXCEEDED,
+                message=f"Too many attempts. Try again in {result.retry_after} seconds.",
+                details={
+                    "limit": result.limit,
+                    "retry_after": result.retry_after,
+                },
+            ).model_dump(),
+            headers={"Retry-After": str(result.retry_after)},
+        )
 
 
 def get_auth_provider(db: AsyncSession = Depends(get_db)) -> AuthProvider:
@@ -73,11 +132,34 @@ async def require_current_user(
 
 @router.post("/register", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
 async def register(
+    request: Request,
     data: UserRegister,
     provider: AuthProvider = Depends(get_auth_provider),
     db: AsyncSession = Depends(get_db),
+    rate_limiter: RateLimiter | None = Depends(get_rate_limiter),
 ) -> AuthResponse:
-    """Register a new user account."""
+    """Register a new user account.
+
+    Security:
+    - Rate limited: 20 requests/5min per IP, 5 requests/5min per email
+    - Honeypot field detection (rejects if 'website' field is filled)
+    """
+    # Check rate limit first
+    await check_auth_rate_limit(request, email=data.email, rate_limiter=rate_limiter)
+
+    # Honeypot check - bots often fill hidden fields
+    if data.website:
+        logger.warning(
+            f"Honeypot triggered for registration: {data.email} from {get_client_ip(request)}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorDetail(
+                code="INVALID_REQUEST",
+                message="Registration failed. Please try again.",
+            ).model_dump(),
+        )
+
     result = await provider.register(data.email, data.password)
 
     if isinstance(result, AuthError):
@@ -123,14 +205,30 @@ async def register(
 
 @router.post("/login", response_model=AuthResponse)
 async def login(
+    request: Request,
     data: UserLogin,
     provider: AuthProvider = Depends(get_auth_provider),
     db: AsyncSession = Depends(get_db),
+    rate_limiter: RateLimiter | None = Depends(get_rate_limiter),
 ) -> AuthResponse:
-    """Login with email and password."""
+    """Login with email and password.
+
+    Security:
+    - Rate limited: 20 requests/5min per IP, 5 requests/5min per email
+    - Account lockout after 5 failed attempts (15 min cooldown)
+    """
+    # Check rate limit first
+    await check_auth_rate_limit(request, email=data.email, rate_limiter=rate_limiter)
+
     result = await provider.login(data.email, data.password)
 
     if isinstance(result, AuthError):
+        # Map ACCOUNT_LOCKED to 429 (rate limit) for consistent client handling
+        if result.code == AuthErrorCode.ACCOUNT_LOCKED:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=result.to_dict(),
+            )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=result.to_dict(),
@@ -162,10 +260,19 @@ async def login(
 
 @router.post("/token", response_model=Token)
 async def login_for_token(
+    request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
     provider: AuthProvider = Depends(get_auth_provider),
+    rate_limiter: RateLimiter | None = Depends(get_rate_limiter),
 ) -> Token:
-    """OAuth2 compatible token endpoint for Swagger UI."""
+    """OAuth2 compatible token endpoint for Swagger UI.
+
+    Security:
+    - Rate limited: 20 requests/5min per IP, 5 requests/5min per email
+    """
+    # Check rate limit
+    await check_auth_rate_limit(request, email=form_data.username, rate_limiter=rate_limiter)
+
     result = await provider.login(form_data.username, form_data.password)
 
     if isinstance(result, AuthError):

--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -220,7 +220,9 @@ async def upload_image(
     responses={
         200: {"model": ImageMetadata},
         404: {"model": ErrorResponse, "description": "Image not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
     },
+    dependencies=[Depends(check_rate_limit)],
 )
 async def get_image_metadata(
     image_id: str,
@@ -270,7 +272,9 @@ async def get_image_metadata(
     responses={
         200: {"content": {"image/jpeg": {}, "image/png": {}}},
         404: {"model": ErrorResponse, "description": "Image not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
     },
+    dependencies=[Depends(check_rate_limit)],
 )
 async def download_image(
     image_id: str,
@@ -301,7 +305,9 @@ async def download_image(
     responses={
         200: {"content": {"image/jpeg": {}}},
         404: {"model": ErrorResponse, "description": "Image or thumbnail not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
     },
+    dependencies=[Depends(check_rate_limit)],
 )
 async def get_thumbnail(
     image_id: str,

--- a/backend/app/api/web.py
+++ b/backend/app/api/web.py
@@ -2,6 +2,9 @@
 
 This module handles server-rendered HTML pages using HTMX + Jinja2.
 All data access goes through ImageService for loose coupling.
+
+Security:
+- Rate limiting on gallery and image pages (prevents scraping)
 """
 
 from fastapi import APIRouter, Depends, Request
@@ -9,7 +12,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import get_cache
-from app.api.images import get_storage
+from app.api.images import check_rate_limit, get_storage
 from app.api.tags import get_tag_service
 from app.config import get_settings
 from app.database import get_db
@@ -141,7 +144,7 @@ async def landing_page(
     )
 
 
-@router.get("/gallery", response_class=HTMLResponse)
+@router.get("/gallery", response_class=HTMLResponse, dependencies=[Depends(check_rate_limit)])
 async def gallery(
     request: Request,
     service: ImageService = Depends(get_image_service),
@@ -150,6 +153,7 @@ async def gallery(
     """
     User's personal gallery (requires authentication).
 
+    Rate limited to prevent scraping.
     This is the renamed home page - shows only the authenticated user's images
     per FR-4.1 unlisted model (no public listing).
     """
@@ -168,7 +172,9 @@ async def gallery(
     )
 
 
-@router.get("/image/{image_id}", response_class=HTMLResponse)
+@router.get(
+    "/image/{image_id}", response_class=HTMLResponse, dependencies=[Depends(check_rate_limit)]
+)
 async def image_detail(
     request: Request,
     image_id: str,
@@ -176,7 +182,7 @@ async def image_detail(
     tag_service: TagService = Depends(get_tag_service),
     user: User | None = Depends(get_current_user_from_cookie),
 ):
-    """Image detail page - Full image with metadata and tags."""
+    """Image detail page - Full image with metadata and tags. Rate limited."""
     image = await service.get_by_id(image_id)
     templates = get_templates(request)
 
@@ -286,13 +292,13 @@ async def auth_callback(
 # =============================================================================
 
 
-@router.get("/my-images", response_class=HTMLResponse)
+@router.get("/my-images", response_class=HTMLResponse, dependencies=[Depends(check_rate_limit)])
 async def my_images(
     request: Request,
     service: ImageService = Depends(get_image_service),
     user: User | None = Depends(get_current_user_from_cookie),
 ):
-    """My Images page - User's uploaded images (requires auth)."""
+    """My Images page - User's uploaded images (requires auth). Rate limited."""
     if not user:
         return RedirectResponse(url="/login", status_code=302)
 
@@ -311,7 +317,9 @@ async def my_images(
 # =============================================================================
 
 
-@router.get("/partials/gallery", response_class=HTMLResponse)
+@router.get(
+    "/partials/gallery", response_class=HTMLResponse, dependencies=[Depends(check_rate_limit)]
+)
 async def gallery_partial(
     request: Request,
     offset: int = 0,
@@ -321,7 +329,7 @@ async def gallery_partial(
 ):
     """Gallery partial - Load more images for HTMX infinite scroll.
 
-    Per FR-4.1: Only shows the authenticated user's images.
+    Rate limited. Per FR-4.1: Only shows the authenticated user's images.
     Returns empty if not authenticated.
     """
     if not user:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,6 +53,15 @@ class Settings(BaseSettings):
     rate_limit_per_minute: int = 10
     rate_limit_window_seconds: int = 60  # 1 minute window
 
+    # Auth Rate Limiting (stricter for security)
+    auth_rate_limit_per_email: int = 5  # Max login attempts per email
+    auth_rate_limit_per_ip: int = 20  # Max auth requests per IP
+    auth_rate_limit_window_seconds: int = 300  # 5 minute window
+
+    # Account Lockout (brute force protection)
+    max_failed_login_attempts: int = 5  # Lock after N consecutive failures
+    account_lockout_minutes: int = 15  # Lockout duration
+
     # Concurrency Control (ADR-0010)
     upload_concurrency_limit: int = 10  # Max simultaneous uploads
     upload_concurrency_timeout: float = 30.0  # Seconds to wait for semaphore

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy import Boolean, DateTime, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -19,6 +19,10 @@ class User(Base):
 
     Supports both local auth (password_hash) and external providers (supabase_id).
     For Supabase users, password_hash may be None as auth is handled externally.
+
+    Security fields:
+    - failed_login_attempts: Counter for consecutive failed logins (brute force protection)
+    - locked_until: Timestamp when lockout expires (15 min after 5 failed attempts)
     """
 
     __tablename__ = "users"
@@ -41,6 +45,18 @@ class User(Base):
     supabase_id: Mapped[str | None] = mapped_column(
         String(36), unique=True, nullable=True, index=True
     )
+
+    # Security: Brute force protection (Phase Security)
+    failed_login_attempts: Mapped[int] = mapped_column(
+        Integer, default=0, nullable=False, server_default="0"
+    )
+    locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    def is_locked(self) -> bool:
+        """Check if account is currently locked due to failed login attempts."""
+        if self.locked_until is None:
+            return False
+        return datetime.now(UTC) < self.locked_until
 
     def __repr__(self) -> str:
         return f"<User(id={self.id}, email={self.email})>"

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -6,10 +6,16 @@ from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 class UserRegister(BaseModel):
-    """User registration request."""
+    """User registration request.
+
+    Security: Includes honeypot field for bot detection.
+    The 'website' field should always be empty - bots often fill hidden fields.
+    """
 
     email: EmailStr
     password: str = Field(..., min_length=8, max_length=128)
+    # Honeypot field - should be empty (hidden from real users)
+    website: str | None = Field(default=None, max_length=255)
 
 
 class UserLogin(BaseModel):

--- a/backend/app/services/auth/base.py
+++ b/backend/app/services/auth/base.py
@@ -22,6 +22,9 @@ class AuthErrorCode(str, Enum):
     PROVIDER_ERROR = "PROVIDER_ERROR"
     WEAK_PASSWORD = "WEAK_PASSWORD"
     INVALID_EMAIL = "INVALID_EMAIL"
+    ACCOUNT_LOCKED = "ACCOUNT_LOCKED"  # Brute force protection
+    RATE_LIMITED = "RATE_LIMITED"  # Auth rate limit exceeded
+    HONEYPOT_TRIGGERED = "HONEYPOT_TRIGGERED"  # Bot detection
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/auth/local.py
+++ b/backend/app/services/auth/local.py
@@ -2,8 +2,15 @@
 
 This provider implements the existing authentication logic from
 auth_service.py, wrapped in the AuthProvider interface.
+
+Security features:
+- bcrypt password hashing (work factor 12)
+- JWT token generation with configurable expiry
+- Timing-safe password verification (prevents timing attacks)
+- Account lockout after N failed attempts (brute force protection)
 """
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 import bcrypt as bcrypt_lib
@@ -20,6 +27,8 @@ from app.services.auth.base import (
     TokenPair,
     UserInfo,
 )
+
+logger = logging.getLogger(__name__)
 
 # bcrypt work factor 12 (takes ~200-400ms to hash)
 BCRYPT_WORK_FACTOR = 12
@@ -136,12 +145,40 @@ class LocalAuthProvider(AuthProvider):
 
         return self._user_to_info(user)
 
+    async def _increment_failed_attempts(self, user: User) -> None:
+        """Increment failed login counter and lock account if threshold reached."""
+        user.failed_login_attempts += 1
+
+        if user.failed_login_attempts >= self._settings.max_failed_login_attempts:
+            user.locked_until = datetime.now(UTC) + timedelta(
+                minutes=self._settings.account_lockout_minutes
+            )
+            logger.warning(
+                f"Account locked for {user.email} after {user.failed_login_attempts} "
+                f"failed attempts. Locked until {user.locked_until}"
+            )
+
+        await self._db.commit()
+
+    async def _reset_failed_attempts(self, user: User) -> None:
+        """Reset failed login counter on successful login."""
+        if user.failed_login_attempts > 0 or user.locked_until is not None:
+            user.failed_login_attempts = 0
+            user.locked_until = None
+            await self._db.commit()
+
     async def login(
         self,
         email: str,
         password: str,
     ) -> tuple[UserInfo, TokenPair] | AuthError:
-        """Authenticate user and return tokens."""
+        """Authenticate user and return tokens.
+
+        Security features:
+        - Timing-safe user enumeration prevention
+        - Account lockout after max_failed_login_attempts failures
+        - Automatic unlock after account_lockout_minutes
+        """
         user = await self._get_user_by_email(email)
 
         if user is None:
@@ -152,7 +189,19 @@ class LocalAuthProvider(AuthProvider):
                 message="Invalid email or password",
             )
 
+        # Check if account is locked
+        if user.is_locked():
+            remaining = user.locked_until - datetime.now(UTC)
+            remaining_minutes = max(1, int(remaining.total_seconds() / 60))
+            logger.warning(f"Login attempt on locked account: {email}")
+            return AuthError(
+                code=AuthErrorCode.ACCOUNT_LOCKED,
+                message=f"Account is locked. Try again in {remaining_minutes} minutes.",
+            )
+
         if not self._verify_password(password, user.password_hash):
+            # Increment failed attempts counter
+            await self._increment_failed_attempts(user)
             return AuthError(
                 code=AuthErrorCode.INVALID_CREDENTIALS,
                 message="Invalid email or password",
@@ -163,6 +212,9 @@ class LocalAuthProvider(AuthProvider):
                 code=AuthErrorCode.USER_INACTIVE,
                 message="User account is inactive",
             )
+
+        # Successful login - reset failed attempts counter
+        await self._reset_failed_attempts(user)
 
         access_token = self._create_access_token(user.id)
         token_pair = TokenPair(

--- a/backend/app/services/rate_limiter.py
+++ b/backend/app/services/rate_limiter.py
@@ -48,9 +48,10 @@ class RateLimiter:
         """Check if rate limiting is enabled."""
         return self._enabled and self._client is not None
 
-    def _allowed_result(self) -> RateLimitResult:
+    def _allowed_result(self, limit: int | None = None) -> RateLimitResult:
         """Return a result that allows the request."""
-        return RateLimitResult(True, 0, self._limit, self._limit)
+        lim = limit or self._limit
+        return RateLimitResult(True, 0, lim, lim)
 
     async def check(self, identifier: str) -> RateLimitResult:
         """Check if request from identifier is allowed."""
@@ -83,6 +84,96 @@ class RateLimiter:
         except RedisError as e:
             logger.warning(f"Rate limiter Redis error, allowing request: {e}")
             return self._allowed_result()
+
+    async def check_auth(
+        self,
+        ip: str,
+        email: str | None = None,
+    ) -> RateLimitResult:
+        """
+        Check auth-specific rate limits (stricter than general rate limit).
+
+        Implements dual rate limiting for auth endpoints:
+        - Per-IP: 20 requests per 5 minutes (prevents distributed attacks)
+        - Per-email: 5 requests per 5 minutes (prevents targeted brute force)
+
+        Args:
+            ip: Client IP address
+            email: Email address being used (optional for registration)
+
+        Returns:
+            RateLimitResult with the most restrictive limit applied
+        """
+        if not self.enabled:
+            return self._allowed_result(limit=settings.auth_rate_limit_per_email)
+
+        window = settings.auth_rate_limit_window_seconds
+
+        try:
+            # Check per-IP limit
+            ip_key = f"{self._key_prefix}:auth:ip:{ip}"
+            ip_limit = settings.auth_rate_limit_per_ip
+
+            async with self._client.pipeline(transaction=True) as pipe:
+                pipe.incr(ip_key)
+                pipe.expire(ip_key, window, nx=True)
+                pipe.ttl(ip_key)
+                ip_results = await pipe.execute()
+
+            ip_count, _, ip_ttl = ip_results[0], ip_results[1], ip_results[2]
+
+            if ip_count > ip_limit:
+                logger.warning(f"Auth rate limit (IP) exceeded for {ip}: {ip_count}/{ip_limit}")
+                return RateLimitResult(
+                    allowed=False,
+                    current_count=ip_count,
+                    limit=ip_limit,
+                    remaining=0,
+                    retry_after=ip_ttl if ip_ttl > 0 else window,
+                )
+
+            # Check per-email limit if email provided
+            if email:
+                email_key = f"{self._key_prefix}:auth:email:{email.lower()}"
+                email_limit = settings.auth_rate_limit_per_email
+
+                async with self._client.pipeline(transaction=True) as pipe:
+                    pipe.incr(email_key)
+                    pipe.expire(email_key, window, nx=True)
+                    pipe.ttl(email_key)
+                    email_results = await pipe.execute()
+
+                email_count, _, email_ttl = email_results[0], email_results[1], email_results[2]
+
+                if email_count > email_limit:
+                    logger.warning(
+                        f"Auth rate limit (email) exceeded for {email}: {email_count}/{email_limit}"
+                    )
+                    return RateLimitResult(
+                        allowed=False,
+                        current_count=email_count,
+                        limit=email_limit,
+                        remaining=0,
+                        retry_after=email_ttl if email_ttl > 0 else window,
+                    )
+
+                return RateLimitResult(
+                    True,
+                    email_count,
+                    email_limit,
+                    max(0, email_limit - email_count),
+                )
+
+            return RateLimitResult(
+                True,
+                ip_count,
+                ip_limit,
+                max(0, ip_limit - ip_count),
+            )
+
+        except RedisError as e:
+            logger.warning(f"Auth rate limiter Redis error, allowing request: {e}")
+            return self._allowed_result(limit=settings.auth_rate_limit_per_email)
 
 
 # Global rate limiter instance (initialized in main.py lifespan)

--- a/backend/app/templates/register.html
+++ b/backend/app/templates/register.html
@@ -67,6 +67,18 @@
             >
         </div>
 
+        <!-- Honeypot field - hidden from real users, bots will fill it -->
+        <div style="position: absolute; left: -9999px;" aria-hidden="true">
+            <label for="website">Website (leave empty)</label>
+            <input
+                type="text"
+                id="website"
+                name="website"
+                tabindex="-1"
+                autocomplete="off"
+            >
+        </div>
+
         <!-- Error Message -->
         <div id="error-message" class="hidden mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded-lg text-sm">
         </div>
@@ -146,6 +158,7 @@
         const email = document.getElementById('email').value;
         const password = document.getElementById('password').value;
         const confirmPassword = document.getElementById('confirm-password').value;
+        const website = document.getElementById('website').value;  // Honeypot
 
         // Client-side validation
         if (password !== confirmPassword) {
@@ -165,12 +178,16 @@
         errorMessage.classList.add('hidden');
 
         try {
+            // Include honeypot field - server will reject if filled
+            const payload = { email, password };
+            if (website) payload.website = website;
+
             const response = await fetch('/api/v1/auth/register', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ email, password }),
+                body: JSON.stringify(payload),
             });
 
             const data = await response.json();


### PR DESCRIPTION
## Summary
- Add rate limiting to `/login`, `/register`, `/token` endpoints (5 attempts/5min per email, 20/5min per IP)
- Implement account lockout after 5 failed login attempts with 15-minute cooldown
- Add honeypot field to registration form for bot detection
- Add rate limiting to GET endpoints (gallery, image metadata, thumbnails)
- Add database migration for new `failed_login_attempts` and `locked_until` fields on User model
- Dual rate limiting strategy: per-IP + per-email for auth endpoints
- Fail-open design: allows requests if Redis unavailable

## Security Features Implemented

| Feature | Description |
|---------|-------------|
| Auth Rate Limiting | 5 attempts/5min per email, 20/5min per IP |
| Account Lockout | 15 min lockout after 5 failed attempts |
| Honeypot Field | Hidden registration field to detect bots |
| GET Rate Limiting | 10 req/min on gallery and image endpoints |

## Configuration

All settings configurable via environment variables:
- `AUTH_RATE_LIMIT_PER_EMAIL` (default: 5)
- `AUTH_RATE_LIMIT_PER_IP` (default: 20)
- `AUTH_RATE_LIMIT_WINDOW_SECONDS` (default: 300)
- `MAX_FAILED_LOGIN_ATTEMPTS` (default: 5)
- `ACCOUNT_LOCKOUT_MINUTES` (default: 15)

## Test Results
- 356 tests passing
- 2 skipped (OpenAI quota - pre-existing)
- 31 integration tests skipped (require Redis/MinIO)

## Rollback Strategy
If issues in production:
```bash
# Option 1: Disable rate limiting
RATE_LIMIT_ENABLED=false

# Option 2: Rollback migration
uv run alembic downgrade -1
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)